### PR TITLE
Fix for iPad Pro icons

### DIFF
--- a/lib/appicon/commands/install.rb
+++ b/lib/appicon/commands/install.rb
@@ -30,7 +30,7 @@ command :'install' do |c|
       image_size = image['size']
       image_scale = image['scale']
 
-      scaled_image_side = image_size.split('x').first.to_i * image_scale.sub('x', '').to_i
+      scaled_image_side = Integer(image_size.split('x').first.to_f * image_scale.sub('x', '').to_f)
       scaled_image_name = "Icon-#{image_size}-@#{image_scale}#{File.extname(@icon)}"
       scaled_image_output = File.join(@icon_set, scaled_image_name)
 


### PR DESCRIPTION
iPad Pro icon size is `83.5x83.5@2x`. The `to_i` calls were causing the output to be off by 1 pixel.

![screenshot](https://cloud.githubusercontent.com/assets/28428/11765715/0ad08f08-a132-11e5-8e84-b177e5b46872.png)
